### PR TITLE
Adding oras provider

### DIFF
--- a/providers/oras/config.go
+++ b/providers/oras/config.go
@@ -1,0 +1,160 @@
+package oras 
+
+// Types and functions for manifests, configs, etc.
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type ImageConfig struct {
+	Architecture string `json:"architecture"`
+	Config       struct {
+		Hostname     string            `json:"Hostname"`
+		Domainname   string            `json:"Domainname"`
+		User         string            `json:"User"`
+		AttachStdin  bool              `json:"AttachStdin"`
+		AttachStdout bool              `json:"AttachStdout"`
+		AttachStderr bool              `json:"AttachStderr"`
+		Tty          bool              `json:"Tty"`
+		OpenStdin    bool              `json:"OpenStdin"`
+		StdinOnce    bool              `json:"StdinOnce"`
+		Env          []string          `json:"Env"`
+		Cmd          []string          `json:"Cmd"`
+		Image        string            `json:"Image"`
+		Volumes      interface{}       `json:"Volumes"`
+		WorkingDir   string            `json:"WorkingDir"`
+		Entrypoint   interface{}       `json:"Entrypoint"`
+		OnBuild      interface{}       `json:"OnBuild"`
+		Labels       map[string]string `json:"Labels"`
+	} `json:"config"`
+	Container       string `json:"container"`
+	ContainerConfig struct {
+		Hostname     string            `json:"Hostname"`
+		Domainname   string            `json:"Domainname"`
+		User         string            `json:"User"`
+		AttachStdin  bool              `json:"AttachStdin"`
+		AttachStdout bool              `json:"AttachStdout"`
+		AttachStderr bool              `json:"AttachStderr"`
+		Tty          bool              `json:"Tty"`
+		OpenStdin    bool              `json:"OpenStdin"`
+		StdinOnce    bool              `json:"StdinOnce"`
+		Env          []string          `json:"Env"`
+		Cmd          []string          `json:"Cmd"`
+		Image        string            `json:"Image"`
+		Volumes      interface{}       `json:"Volumes"`
+		WorkingDir   string            `json:"WorkingDir"`
+		Entrypoint   interface{}       `json:"Entrypoint"`
+		OnBuild      interface{}       `json:"OnBuild"`
+		Labels       map[string]string `json:"Labels"`
+	} `json:"container_config"`
+	Created       time.Time `json:"created"`
+	DockerVersion string    `json:"docker_version"`
+	History       []struct {
+		Created    time.Time `json:"created"`
+		CreatedBy  string    `json:"created_by"`
+		EmptyLayer bool      `json:"empty_layer,omitempty"`
+	} `json:"history"`
+	Os     string `json:"os"`
+	Rootfs struct {
+		Type    string   `json:"type"`
+		DiffIds []string `json:"diff_ids"`
+	} `json:"rootfs"`
+}
+
+
+type ImageManifest struct {
+	SchemaVersion int `json:"schemaVersion"`
+	Config        struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+		Size      int    `json:"size"`
+	} `json:"config"`
+	Layers []struct {
+		MediaType   string `json:"mediaType"`
+		Digest      string `json:"digest"`
+		Size        int    `json:"size"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"layers"`
+}
+
+func GetRequest(url string, headers map[string]string) (string, error) {
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	// Read the response from the body, and return as string
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+
+// GetImageManifest of an existing oras image
+func GetImageManifest(container string) (ImageManifest, error) {
+
+	url := "https://crane.ggcr.dev/manifest/" + container
+	manifest := ImageManifest{}
+	response, err := GetRequest(url, map[string]string{})
+	if err != nil {
+		return manifest, err
+	}
+	json.Unmarshal([]byte(response), &manifest)
+	return manifest, err
+}
+
+
+// GetImageDigest gets a digest based on a full URI with tag
+func GetImageDigest(container string) (string, error) {
+
+	url := "https://crane.ggcr.dev/digest/" + container
+	response, err := GetRequest(url, map[string]string{})
+	if err != nil {
+		return "", err
+	}
+	return string(response), nil
+}
+
+
+// GetImageConfig of an existing container
+func GetImageConfig(container string) (ImageConfig, error) {
+
+	// Get tags for current container image
+	configUrl := "https://crane.ggcr.dev/config/" + container
+	imageConf := ImageConfig{}
+	response, err := GetRequest(configUrl, map[string]string{})
+	if err != nil {
+		return imageConf, err
+	}
+	json.Unmarshal([]byte(response), &imageConf)
+	return imageConf, err
+}
+
+// Get image tags for a container
+func GetImageTags(container string) ([]string, error) {
+	tags := []string{}
+	tagsUrl := "https://crane.ggcr.dev/ls/" + container
+	response, err := GetRequest(tagsUrl, map[string]string{})
+	if err != nil {
+		return tags, err
+	}
+	tags = strings.Split(response, "\n")
+	return tags, err
+}

--- a/providers/oras/containers.go
+++ b/providers/oras/containers.go
@@ -1,0 +1,96 @@
+package oras
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/DataDrake/cuppa/results"
+	"github.com/DataDrake/cuppa/version"
+	"github.com/docker/distribution/reference"
+)
+
+
+
+func (c Provider) GetImages(url string) (rs *results.ResultSet, err error) {
+	result := results.ResultSet{}
+
+	// Normalize the url without the tag.
+	urlNormalized := strings.Replace(url, "oras://", "", 1)
+	urlData := strings.SplitN(url, ":", 3)
+	
+	// Regular expressions for versions
+	vexp := regexp.MustCompile(`^([0-9]{1,4}[.])+[0-9,a-d]{1,4}`)
+	vexpStrict := regexp.MustCompile(`^([0-9]{1,4}[.])+[0-9,a-d]{1,4}$`)
+	
+	// Prepare filter for tags, if provided
+	filter := "*"
+	if len(urlData) > 2 {
+		filter = urlData[2]
+	}
+	tags, err := GetImageTags(urlNormalized)
+	if err != nil {
+		return rs, err
+	}
+
+	latest := version.NewVersion("")
+	latestTag := ""
+	for _, tag := range tags {
+		matched, err := filepath.Match(filter, tag)
+		if err != nil {
+			return rs, err
+		}
+		if matched {
+			verString := vexp.FindString(tag)
+			new := version.NewVersion(verString)
+			if latest.String() == "N/A" || (verString != "" && new.Compare(latest) < 0) {
+				latest = new
+				latestTag = tag
+			}
+		}
+	}
+	if latest.String() != "N/A" {
+		filter = latestTag
+	}
+
+	for _, tag := range tags {
+
+		if tag == "" {
+			continue
+		}
+		matched, err := filepath.Match(filter, tag)
+		if err != nil {
+			return rs, err
+		}
+		if matched {
+			ref, err := reference.ParseNormalizedNamed(urlNormalized + ":" + tag)
+			if err != nil {
+				return rs, err
+			}
+			sha, err := GetImageDigest(ref.String())
+			if err != nil {
+				return rs, err
+			}
+			output := results.NewResult(
+				sha,
+				tag,
+				"oras://"+ref.String(),
+
+				// Most of these don't have a time, so we use now
+				time.Now(),
+			)
+
+			// Work around CUPPA's default version handling.
+			if !vexpStrict.MatchString(tag) {
+				output.Version = []string{tag}
+			}
+			result.AddResult(output)
+		}
+	}
+
+	if result.Len() < 1 {
+		return nil, results.NotFound
+	}
+	return &result, nil
+}

--- a/providers/oras/provider.go
+++ b/providers/oras/provider.go
@@ -1,0 +1,43 @@
+package oras
+
+import (
+	"regexp"
+
+	"github.com/DataDrake/cuppa/results"
+)
+
+var (
+	// SourceRegex is the regex for Docker sources
+	SourceRegex = regexp.MustCompile("oras://([^/]*/[^/.]*)*")
+)
+
+// Provider is the upstream provider interface for docker.
+type Provider struct{}
+
+// String gives the name of this provider
+func (c Provider) String() string {
+	return "Oras"
+}
+
+// Match check to see of this provider can handle this kind of query
+func (c Provider) Match(query string) (params []string) {
+	if sm := SourceRegex.FindStringSubmatch(query); len(sm) > 1 {
+		params = []string{query}
+	}
+	return
+}
+
+// Latest finds the newest release for an oras artifact
+func (c Provider) Latest(params []string) (r *results.Result, err error) {
+	rs, err := c.GetImages(params[0])
+	if err == nil {
+		r = rs.Last()
+	}
+	return
+}
+
+// Releases finds all matching releases for an oras artifact
+func (c Provider) Releases(params []string) (rs *results.ResultSet, err error) {
+	rs, err = c.GetImages(params[0])
+	return
+}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDrake/cuppa/providers/jetbrains"
 	"github.com/DataDrake/cuppa/providers/kde"
 	"github.com/DataDrake/cuppa/providers/launchpad"
+	"github.com/DataDrake/cuppa/providers/oras"
 	"github.com/DataDrake/cuppa/providers/pypi"
 	"github.com/DataDrake/cuppa/providers/rubygems"
 	"github.com/DataDrake/cuppa/providers/sourceforge"
@@ -57,6 +58,7 @@ func All() []Provider {
 		jetbrains.Provider{},
 		kde.Provider{},
 		launchpad.Provider{},
+		oras.Provider{},
 		pypi.Provider{},
 		rubygems.Provider{},
 		sourceforge.Provider{},


### PR DESCRIPTION
Okay, I think I got this working to add oras! If this works here, then lookout should be able to use it, and then binoc, and then the shpc parser there!

```bash
$ go run cuppa.go latest oras://ghcr.io/singularityhub/github-ci
 ⮞  Oras checking for match:
Name      : sha256:227a917e9ce3a6e1a3727522361865ca92f3147fd202fa1b2e6a7a8220d510b7
Version   : latest
Location  : oras://ghcr.io/singularityhub/github-ci:latest
Published : 2022-01-30T19:01:53-07:00

 🗸  Oras match(es) found.
 🗸  Done
```
and in pretty colors:

![image](https://user-images.githubusercontent.com/814322/151729462-d7ac1808-e4b5-4a99-b866-e863ee6de63c.png)

